### PR TITLE
Add TextEditor/QueryDocument mocks and a few fixes

### DIFF
--- a/lib/mocks/azdata/index.ts
+++ b/lib/mocks/azdata/index.ts
@@ -3,5 +3,5 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export * as azdata from './azdata';
-export * as vscode from './vscode';
+export * as queryeditor from './queryeditor';
+export * as modelView from './modelView';

--- a/lib/mocks/azdata/modelView/index.ts
+++ b/lib/mocks/azdata/modelView/index.ts
@@ -3,5 +3,4 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export * as azdata from './azdata';
-export * as vscode from './vscode';
+export * from './modelViewMock';

--- a/lib/mocks/azdata/modelView/modelViewMock.ts
+++ b/lib/mocks/azdata/modelView/modelViewMock.ts
@@ -5,14 +5,14 @@
 
 import * as azdata from 'azdata';
 import * as TypeMoq from 'typemoq';
-import { StubButton } from '../../stubs/modelView/stubButton';
-import { StubCheckbox } from '../../stubs/modelView/stubCheckbox';
-import { StubDivContainer } from '../../stubs/modelView/stubDivContainer';
-import { StubFlexContainer } from '../../stubs/modelView/stubFlexContainer';
-import { StubInputBox } from '../../stubs/modelView/stubInputBox';
-import { StubRadioButton } from '../../stubs/modelView/stubRadioButton';
-import { StubText } from '../../stubs/modelView/stubText';
-import { StubToolbarContainer } from '../../stubs/modelView/stubToolbarContainer';
+import { StubButton } from '../../../stubs/modelView/stubButton';
+import { StubCheckbox } from '../../../stubs/modelView/stubCheckbox';
+import { StubDivContainer } from '../../../stubs/modelView/stubDivContainer';
+import { StubFlexContainer } from '../../../stubs/modelView/stubFlexContainer';
+import { StubInputBox } from '../../../stubs/modelView/stubInputBox';
+import { StubRadioButton } from '../../../stubs/modelView/stubRadioButton';
+import { StubText } from '../../../stubs/modelView/stubText';
+import { StubToolbarContainer } from '../../../stubs/modelView/stubToolbarContainer';
 
 export type ComponentAndMockComponentBuilder<C, B> = {
 	component: C,

--- a/lib/mocks/azdata/queryeditor/index.ts
+++ b/lib/mocks/azdata/queryeditor/index.ts
@@ -3,5 +3,4 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export * as azdata from './azdata';
-export * as vscode from './vscode';
+export * from './queryDocumentMock';

--- a/lib/mocks/azdata/queryeditor/queryDocumentMock.ts
+++ b/lib/mocks/azdata/queryeditor/queryDocumentMock.ts
@@ -1,0 +1,20 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as azdata from 'azdata';
+import * as TypeMoq from 'typemoq';
+
+/**
+ * Creates a mock of a azdata.queryeditor.QueryDocument
+ * @param uri The URI to give the document
+ * @param providerId The providerId for the document. Defaults to MSSQL
+ * @returns The mocked document
+ */
+export function createQueryDocumentMock(uri: string, providerId: string = 'MSSQL'): TypeMoq.IMock<azdata.queryeditor.QueryDocument> {
+	const mock = TypeMoq.Mock.ofType<azdata.queryeditor.QueryDocument>();
+	mock.setup(m => m.uri).returns(() => uri);
+	mock.setup(m => m.providerId).returns(() => providerId);
+	return mock;
+}

--- a/lib/mocks/vscode/index.ts
+++ b/lib/mocks/vscode/index.ts
@@ -3,4 +3,5 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-export { createTextDocumentMock, RangeWithContent } from './textDocumentMock';
+export * from './textDocumentMock';
+export * from './textEditorMock';

--- a/lib/mocks/vscode/textDocumentMock.ts
+++ b/lib/mocks/vscode/textDocumentMock.ts
@@ -9,7 +9,7 @@ import * as TypeMoq from 'typemoq';
 export type RangeWithContent = { range: vscode.Range, content: string };
 
 /**
- * Creates a mock of a vscode.TextDocument 
+ * Creates a mock of a vscode.TextDocument
  * @param uri The URI to give the document
  * @param contentOrRanges The content of the document. If just a string then that is returned when all context is gotten from the document, otherwise the array is a set of range to content mappings to return when that specified range is requested
  * @returns The mocked document
@@ -21,7 +21,7 @@ export function createTextDocumentMock(uri: vscode.Uri, contentOrRanges: string 
 		mock.setup(m => m.getText(undefined)).returns(() => contentOrRanges);
 	} else {
 		for (const rangeWithContent of contentOrRanges) {
-			mock.setup(m => m.getText(rangeWithContent.range)).returns(() => rangeWithContent.content);
+			mock.setup(m => m.getText(TypeMoq.It.is<vscode.Range>(r => r.isEqual(rangeWithContent.range)))).returns(() => rangeWithContent.content);
 		}
 	}
 	return mock;

--- a/lib/mocks/vscode/textEditorMock.ts
+++ b/lib/mocks/vscode/textEditorMock.ts
@@ -1,0 +1,22 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the Source EULA. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as vscode from 'vscode';
+import * as TypeMoq from 'typemoq';
+
+/**
+ * Creates a mock of a vscode.TextEditor
+ * @param document The underlying document for this editor
+ * @param selections The current selections for the document. Defaults to an empty selection at position 0,0.
+ * @returns The mocked editor
+ */
+export function createTextEditorMock(document: vscode.TextDocument, selections?: vscode.Selection[]): TypeMoq.IMock<vscode.TextEditor> {
+	selections  = (!selections || selections.length === 0) ? [new vscode.Selection(new vscode.Position(0, 0), new vscode.Position(0, 0))] : selections;
+	const mock = TypeMoq.Mock.ofType<vscode.TextEditor>();
+	mock.setup(m => m.document).returns(() => document);
+	mock.setup(m => m.selection).returns(() => selections[0]);
+	mock.setup(m => m.selections).returns(() => selections);
+	return mock;
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/azdata-test",
-  "version": "2.0.0",
+  "version": "1.5.2",
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/azdata-test",
-  "version": "1.5.2",
+  "version": "2.0.0",
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",
@@ -19,7 +19,7 @@
     "typemoq": "^2.1.0"
   },
   "devDependencies": {
-    "@types/azdata": "^1.37.0",
+    "@types/azdata": "^1.38.0",
     "@types/node": "^12.11.7",
     "@types/rimraf": "^2.0.2",
     "standard-version": "^9.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,10 +23,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@types/azdata@^1.37.0":
-  version "1.37.0"
-  resolved "https://registry.yarnpkg.com/@types/azdata/-/azdata-1.37.0.tgz#0557e7993939ee4d099548b3d708d33483ca6d2c"
-  integrity sha512-chmfkfvv9pfvBqWtFyvYatb4vvv7ljlySMFH1kDIXRXQLZ6iswzW2+RnzqKpB51jL4gmjUEKB7Rf+WloDaN7rg==
+"@types/azdata@^1.38.0":
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/@types/azdata/-/azdata-1.38.0.tgz#205d8366c28df15d2514dd86fce06a52cd233546"
+  integrity sha512-yXvy8+j2LgWoe7cX33doTDdv/0d7LMDEm3IfrXZ/EU4AwwzjvKqSR/0Ae0CH3o8WOvDm63bws++gxDlmhoLsPg==
   dependencies:
     "@types/vscode" "*"
 


### PR DESCRIPTION
- Add vscode.TextEditor mock helper
- Add azdata.queryeditor.QueryDocument mock helper
- Moved modelView stuff under azdata namespace to more easily separate out vscode and azdata helpers
- Fix TextDocument mock to not do direct equality check for the ranges in GetText but rather do an IsEqual call to determine if they're equal which will compare the actual start and end locations