### PR TITLE
Update StubInputBox to use azdata.AriaLiveValue

### DIFF
--- a/lib/stubs/azdata/modelView/stubInputBox.ts
+++ b/lib/stubs/azdata/modelView/stubInputBox.ts
@@ -11,7 +11,7 @@ export class StubInputBox extends StubComponent implements azdata.InputBoxCompon
 	readonly id = 'input-box';
 
 	value?: string;
-	ariaLive?: string;
+	ariaLive?: azdata.AriaLiveValue;
 	placeHolder?: string;
 	inputType?: azdata.InputBoxInputType;
 	required?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/azdata-test",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -w -p ./",

--- a/typings/azdata.proposed.d.ts
+++ b/typings/azdata.proposed.d.ts
@@ -1525,4 +1525,9 @@ declare module 'azdata' {
 		 */
 		link: LinkArea;
 	}
+
+	/**
+	 * Supported values for aria-live accessibility attribute
+	 */
+	export type AriaLiveValue = 'polite' | 'assertive' | 'off';
 }


### PR DESCRIPTION
ariaLive was updated to accept the type azdata.AriaLiveValue instead of string in https://github.com/microsoft/azuredatastudio/pull/22338